### PR TITLE
Update Sel-Utility.lua

### DIFF
--- a/libs/Sel-Utility.lua
+++ b/libs/Sel-Utility.lua
@@ -606,7 +606,7 @@ function set_macro_page(set,book)
             add_to_chat(123,'Error setting macro page: Macro book ('..tostring(book)..') must be between 1 and 40.')
             return
         end
-        send_command('@input /macro book '..tostring(book)..';wait .1;input /macro set '..tostring(set))
+        send_command('@input /macro book '..tostring(book)..';wait 2;input /macro set '..tostring(set))
     else
         send_command('@input /macro set '..tostring(set))
     end


### PR DESCRIPTION
Sending the /macro book and /macro set commands too close together is a known cause of *losing all one's macros* under certain circumstances.

The .1 is a legacy from mote's libraries, but there's no reason for it to be that low since macro book changes can only happen in mog house/at nomad moogles, and the job change animation takes longer than 2s anyway. Even when using job change addons the longer delay is totally unnoticeable. There's no reason for it to be that low, and having it at 2s makes the "disappearing macro" issue completely go away. &lt;/rant&gt;