### PR TITLE
Refactored code for pwunlock to be precise for the 3s tick with scheduling and tickdelay

### DIFF
--- a/libs/Sel-Include.lua
+++ b/libs/Sel-Include.lua
@@ -1647,7 +1647,9 @@ function get_idle_set(petStatus)
 		elseif state.Weapons.value == 'None' or state.UnlockWeapons.value then
 				idleSet = set_combine(idleSet, sets.IdleWakeUp)
 		elseif state.PWUnlock.value then
-			windower.send_command('gs c set unlockweapons true; wait 1; gs c set unlockweapons false')
+			send_command('@input //gs c set unlockweapons true')
+			windower.chat.input:schedule(3,'//gs c set unlockweapons false')
+			tickdelay = os.clock() + 1.25
 			idleSet = set_combine(idleSet, sets.IdleWakeUp)
 		end
 	end
@@ -1755,7 +1757,9 @@ function get_melee_set()
 		elseif state.Weapons.value == 'None' or state.UnlockWeapons.value then
 			meleeSet = set_combine(meleeSet, sets.buff.Sleep)
 		elseif state.PWUnlock.value then
-			windower.send_command('gs c set unlockweapons true; wait 1; gs c set unlockweapons false')
+			send_command('@input //gs c set unlockweapons true')
+			windower.chat.input:schedule(3,'//gs c set unlockweapons false')
+			tickdelay = os.clock() + 1.25
 			meleeSet = set_combine(meleeSet, sets.buff.Sleep)
 		end
 	end


### PR DESCRIPTION
I tested it locally but not extensively, the new code ensures that the 3 seconds of server tick you're equipping the weapon as the wait 1 was too short and sometimes it would spam endlessly to try and wake you up.

It should be slightly better also when lagging if I understand scheduling/tickdelay well enough. Could be worth headtat/shadowmeld/others giving it a try locally before merging just in case but seems to work for me.