### PR TITLE
Enhancing autows_list

### DIFF
--- a/libs/Sel-Include.lua
+++ b/libs/Sel-Include.lua
@@ -236,6 +236,7 @@ function init_include()
 	autonuke = 'Fire'
 	autows = ''
 	autows_list = {}
+	weapons_pagelist = {}
 	smartws = nil
 	rangedautows = ''
 	autowstp = 1000
@@ -2344,9 +2345,18 @@ function state_change(stateField, newValue, oldValue)
 			newValue = state.Weapons.value
 			if not state.ReEquip.value then	equip_weaponset(newValue) end
 		end
-		
+
 		if autows_list[newValue] then
-			autows = autows_list[newValue]
+			if type(autows_list[newValue]) == "table" then
+				autows 		= autows_list[newValue][1]
+				autowstp 	= autows_list[newValue][2]
+			else
+				autows 		= autows_list[newValue]
+			end
+		end
+
+		if weapons_pagelist[newValue] then
+			set_macro_page(weapons_pagelist[newValue][1], weapons_pagelist[newValue][2])
 		end
 	elseif stateField == 'Unlock Weapons' then
 		if newValue == true then

--- a/libs/Sel-SelfCommands.lua
+++ b/libs/Sel-SelfCommands.lua
@@ -413,7 +413,12 @@ function handle_weapons(cmdParams)
 	end
 
 	if autows_list[state.Weapons.value] then
-		autows = autows_list[state.Weapons.value]
+		if type(autows_list[state.Weapons.value]) == "table" then
+			autows 		= autows_list[state.Weapons.value][1]
+			autowstp 	= autows_list[state.Weapons.value][2]
+		else
+			autows 		= autows_list[state.Weapons.value]
+		end
 	end
 
 	if state.DisplayMode.value then update_job_states()	end


### PR DESCRIPTION
Adding support for supplying a tp value to the autows_list entry.  e.g.:

autows_list =
{
["Sword"] = "Savage Blade",
["Polearm"] = {"Impulse Drive", 1750},
}

Will accept both, so older versions will still work.

Also added an optional variable for weapons_pagelist.  This will let you automatically change macro sets when changing weapon states.

weapons_pagelist =
{
	['Staff']		= {4, 13},
	['Club']		= {5, 13},
}

Completely optional, just add to gear file if you want to use it.