### PR TITLE
Update Sel-Include.lua

### DIFF
--- a/libs/Sel-Include.lua
+++ b/libs/Sel-Include.lua
@@ -592,7 +592,7 @@ end
 -- Non item-based global settings to check on load.
 function global_on_load()
 	if world.area then
-		set_dual_wield()
+		set_dual_wield:schedule(3)
 		
 		if world.area:contains('Abyssea') or data.areas.proc:contains(world.area) then
 			state.SkipProcWeapons:set('False')
@@ -2213,7 +2213,7 @@ end
 
 -- Called when the player's subjob changes.
 function sub_job_change(newSubjob, oldSubjob)
-	set_dual_wield()
+	set_dual_wield:schedule(2)
     if user_setup then
         user_setup()
     end


### PR DESCRIPTION
Following PR #31, the `set_dual_wield()` function needs to be delayed a little during lua events to give time to character update packets to arrive to the client (as usual lua is too fast)